### PR TITLE
Fix API response for clients

### DIFF
--- a/api.php
+++ b/api.php
@@ -30,7 +30,7 @@ $action = $_GET['action'] ?? null;
 switch ($action) {
     case 'get_clients':
         echo json_encode($database['clients'], JSON_UNESCAPED_UNICODE);
-        break;
+        exit;
     case 'add_client':
         $data = json_decode(file_get_contents('php://input'), true);
         $new = [


### PR DESCRIPTION
## Summary
- correct `get_clients` API response to stop overwriting JSON output

## Testing
- `php -l api.php` *(fails: command not found)*
