### PR TITLE
Improve auto rebase workflow

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, labeled]
 
 jobs:
-  rebase:
+  auto-rebase:
     if: startsWith(github.event.pull_request.head.ref, 'codex/') ||
         contains(join(github.event.pull_request.labels.*.name, ','), 'codex')
     runs-on: ubuntu-latest
@@ -17,6 +17,11 @@ jobs:
         with:
           token: ${{ secrets.CUSTOM_GH_TOKEN }}
           fetch-depth: 0
+
+      - name: Set git identity
+        run: |
+          git config user.name "codex-bot"
+          git config user.email "bot@example.com"
 
       - name: Register merge drivers
         run: |
@@ -30,4 +35,22 @@ jobs:
           git commit -m 'ci: add merge drivers' || true
 
       - name: Rebase onto main
-        uses: cirrus-actions/rebase@v3
+        id: rebase
+        run: |
+          git fetch origin main
+          if ! git rebase origin/main -X ours; then
+            echo "conflicted=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Auto-resolve docs
+        if: steps.rebase.outputs.conflicted == 'true'
+        run: |
+          git diff --name-only --diff-filter=U | \
+            grep -E '(^README\\.md$|\\.html$)' | \
+            xargs -I{} git checkout --theirs {}
+          git add -u
+          git rebase --continue || git rebase --skip
+
+      - name: Push changes
+        if: success()
+        run: git push --force-with-lease


### PR DESCRIPTION
## Summary
- extend workflow to rebase using git directly
- auto-resolve documentation conflicts
- push rebased branch automatically

## Testing
- `php -l api.php` *(fails: command not found)*
- `git status --short`
